### PR TITLE
Dynamic Port-forwarding Pt.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -59,8 +59,10 @@ require (
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/rogpeppe/go-internal v1.11.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
+	github.com/thediveo/enumflag/v2 v2.0.5 // indirect
 	github.com/xlab/treeprint v1.2.0 // indirect
 	go.starlark.net v0.0.0-20230612165344-9532f5667272 // indirect
+	golang.org/x/exp v0.0.0-20231006140011-7918f672742d // indirect
 	golang.org/x/net v0.19.0 // indirect
 	golang.org/x/oauth2 v0.10.0 // indirect
 	golang.org/x/sync v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -163,6 +163,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+github.com/thediveo/enumflag/v2 v2.0.5 h1:VJjvlAqUb6m6mxOrB/0tfBJI0Kvi9wJ8ulh38xK87i8=
+github.com/thediveo/enumflag/v2 v2.0.5/go.mod h1:0NcG67nYgwwFsAvoQCmezG0J0KaIxZ0f7skg9eLq1DA=
 github.com/xlab/treeprint v1.2.0 h1:HzHnuAF1plUN2zGlAFHbSQP2qJ0ZAD3XF5XD7OesXRQ=
 github.com/xlab/treeprint v1.2.0/go.mod h1:gj5Gd3gPdKtR1ikdDK6fnFLdmIS0X30kTTuNd/WEJu0=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
@@ -173,6 +175,8 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
+golang.org/x/exp v0.0.0-20231006140011-7918f672742d h1:jtJma62tbqLibJ5sFQz8bKtEM8rJBtfilJ2qTU199MI=
+golang.org/x/exp v0.0.0-20231006140011-7918f672742d/go.mod h1:ldy0pHrwJyGW56pPQzzkH36rKxoZW1tw7ZJpeKx+hdo=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=

--- a/pkg/dynaward/command.go
+++ b/pkg/dynaward/command.go
@@ -10,6 +10,8 @@ import (
 func NewCommand(f cmdutil.Factory, s genericiooptions.IOStreams) *cobra.Command {
 	o := &Options{
 		IOStreams: s,
+		Listen:    "localhost:3128",
+		Verbosity: InfoVerbosityLevel,
 	}
 
 	cmd := &cobra.Command{
@@ -24,5 +26,6 @@ func NewCommand(f cmdutil.Factory, s genericiooptions.IOStreams) *cobra.Command 
 		SuggestFor: []string{"sh"},
 	}
 
+	o.Bind(cmd)
 	return cmd
 }

--- a/pkg/dynaward/options.go
+++ b/pkg/dynaward/options.go
@@ -2,8 +2,10 @@ package dynaward
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
+	"github.com/thediveo/enumflag/v2"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 )
@@ -11,9 +13,20 @@ import (
 type Options struct {
 	genericiooptions.IOStreams
 
+	Listen string
+
+	Verbosity VerbosityLevel
+
 	Namespaces        []string
 	AllNamespaces     bool
 	ExplicitNamespace bool
+}
+
+func (o *Options) Bind(cmd *cobra.Command) {
+	cmd.PersistentFlags().StringVarP(&o.Listen, "listen", "L", o.Listen, "Listen IP:port")
+
+	vl := enumflag.New(&o.Verbosity, "verbosity", VerbosityLevelOptions, enumflag.EnumCaseSensitive)
+	cmd.PersistentFlags().VarP(vl, "log-level", "l", "Log verbosity level, one of: info, debug, trace (default: info)")
 }
 
 // Complete takes the command arguments and factory and infers any remaining options.
@@ -42,6 +55,10 @@ func (o *Options) Complete(f cmdutil.Factory, cmd *cobra.Command, args []string)
 func (o *Options) Validate(_ *cobra.Command) error {
 	if len(o.Namespaces) > 0 && o.AllNamespaces {
 		return fmt.Errorf("only one of --namespace or --all-namespaces may be set")
+	}
+
+	if !strings.Contains(o.Listen, ":") {
+		return fmt.Errorf("expecting listen %q to contain ':' in the form of IP:PORT", o.Listen)
 	}
 
 	return nil

--- a/pkg/dynaward/options.go
+++ b/pkg/dynaward/options.go
@@ -15,6 +15,7 @@ type Options struct {
 
 	Listen string
 
+	Control   bool
 	Verbosity VerbosityLevel
 
 	Namespaces        []string
@@ -23,6 +24,7 @@ type Options struct {
 }
 
 func (o *Options) Bind(cmd *cobra.Command) {
+	cmd.PersistentFlags().BoolVarP(&o.Control, "control", "c", o.Control, "Enable control endpoint")
 	cmd.PersistentFlags().StringVarP(&o.Listen, "listen", "L", o.Listen, "Listen IP:port")
 
 	vl := enumflag.New(&o.Verbosity, "verbosity", VerbosityLevelOptions, enumflag.EnumCaseSensitive)

--- a/pkg/dynaward/runner.go
+++ b/pkg/dynaward/runner.go
@@ -1,6 +1,7 @@
 package dynaward
 
 import (
+	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
@@ -38,6 +39,17 @@ func (o *Options) Run(f cmdutil.Factory) error {
 	return http.ListenAndServe(o.Listen, handler)
 }
 
+func (o *Options) controlIndex(w http.ResponseWriter, r *http.Request) {
+	fwd := ExtractForwardPool(r)
+	fwd.mut.RLock()
+	defer fwd.mut.RUnlock()
+
+	fmt.Fprintf(w, "[ %d active port-forwards ]\n", len(fwd.cache))
+	for host, fc := range fwd.cache {
+		fmt.Fprintf(w, "%s -> %s/%s:%d\n", host, fc.Namespace, fc.PodName, fc.PodPort)
+	}
+}
+
 func (o *Options) wrapServe(logger *slog.Logger, f cmdutil.Factory) (http.HandlerFunc, func(), error) {
 	kc, err := f.KubernetesClientSet()
 	if err != nil {
@@ -57,18 +69,36 @@ func (o *Options) wrapServe(logger *slog.Logger, f cmdutil.Factory) (http.Handle
 		mut:    sync.RWMutex{},
 	}
 
+	ctrl := http.NewServeMux()
+	ctrl.HandleFunc("/", o.controlIndex)
+	ctrl.HandleFunc("/favicon.ico", http.NotFound)
+
 	hnd := func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 		t0 := time.Now()
-		logger.Info("Received request", "path", r.URL.Path, "host", r.Host, "method", r.Method, "url", r.URL.String())
+
+		if r.Host == o.Listen {
+			if o.Control {
+				logger.Info("Received control request", "host", r.Host, "path", r.URL.Path)
+				ctrl.ServeHTTP(w, InjectForwardPool(r, fwd))
+			} else {
+				logger.Error("Received control request, but control endpoint disabled", "host", r.Host)
+				http.Error(w, "Control endpoint disabled", http.StatusForbidden)
+			}
+			return
+		}
+
+		logger.Info("Received proxy request", "path", r.URL.Path, "host", r.Host, "method", r.Method, "url", r.URL.String())
 
 		if r.Method == http.MethodConnect {
+			logger.Error("This proxy does not support 'CONNECT' yet", "path", r.URL.Path, "host", r.Host)
 			http.Error(w, "This proxy does not support 'CONNECT' yet", http.StatusMethodNotAllowed)
 			return
 		}
 
 		fc, err := fwd.ConnectionFor(ctx, r.Host)
 		if err != nil {
+			logger.Error("Error: "+err.Error(), "path", r.URL.Path, "host", r.Host)
 			http.Error(w, "Error: "+err.Error(), http.StatusInternalServerError)
 			return
 		}
@@ -82,6 +112,7 @@ func (o *Options) wrapServe(logger *slog.Logger, f cmdutil.Factory) (http.Handle
 
 		estream, err := fc.Conn.CreateStream(hdr)
 		if err != nil {
+			logger.Error("cannot create error stream: "+err.Error(), "path", r.URL.Path, "host", r.Host)
 			http.Error(w, "cannot create error stream: "+err.Error(), http.StatusInternalServerError)
 			return
 		}
@@ -91,6 +122,7 @@ func (o *Options) wrapServe(logger *slog.Logger, f cmdutil.Factory) (http.Handle
 		hdr.Set(corev1.StreamType, corev1.StreamTypeData)
 		dstream, err := fc.Conn.CreateStream(hdr)
 		if err != nil {
+			logger.Error("cannot create data stream: "+err.Error(), "path", r.URL.Path, "host", r.Host)
 			http.Error(w, "cannot create data stream: "+err.Error(), http.StatusInternalServerError)
 			return
 		}
@@ -100,16 +132,19 @@ func (o *Options) wrapServe(logger *slog.Logger, f cmdutil.Factory) (http.Handle
 		_ = r2.Body.Close()
 
 		if err := r2.Write(dstream); err != nil {
+			logger.Error("cannot write request to data stream: "+err.Error(), "path", r.URL.Path, "host", r.Host)
 			http.Error(w, "cannot write request to data stream: "+err.Error(), http.StatusInternalServerError)
 			return
 		}
 		if err := dstream.Close(); err != nil {
+			logger.Error("cannot close data stream: "+err.Error(), "path", r.URL.Path, "host", r.Host)
 			http.Error(w, "cannot close data stream: "+err.Error(), http.StatusInternalServerError)
 			return
 		}
 
 		n, err := io.Copy(w, dstream)
 		if err != nil {
+			logger.Error("cannot copy response from data stream: "+err.Error(), "path", r.URL.Path, "host", r.Host)
 			http.Error(w, "cannot copy response from data stream: "+err.Error(), http.StatusInternalServerError)
 			return
 		}

--- a/pkg/dynaward/runner.go
+++ b/pkg/dynaward/runner.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strconv"
 	"sync"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
@@ -13,9 +14,15 @@ import (
 )
 
 func (o *Options) Run(f cmdutil.Factory) error {
-	logger := slog.New(slog.NewJSONHandler(o.ErrOut, &slog.HandlerOptions{
-		AddSource: false,
-	}))
+	sho := slog.HandlerOptions{}
+	switch o.Verbosity {
+	case InfoVerbosityLevel:
+		sho.Level = slog.LevelInfo
+	default:
+		sho.Level = slog.LevelDebug
+	}
+
+	logger := slog.New(slog.NewJSONHandler(o.ErrOut, &sho))
 	handler, closer, err := o.wrapServe(logger, f)
 	if err != nil {
 		return err
@@ -27,9 +34,8 @@ func (o *Options) Run(f cmdutil.Factory) error {
 		}
 	}()
 
-	addr := "localhost:3128"
-	logger.Info("Listening", "addr", addr)
-	return http.ListenAndServe(addr, handler)
+	logger.Info("Listening", "addr", o.Listen)
+	return http.ListenAndServe(o.Listen, handler)
 }
 
 func (o *Options) wrapServe(logger *slog.Logger, f cmdutil.Factory) (http.HandlerFunc, func(), error) {
@@ -53,6 +59,7 @@ func (o *Options) wrapServe(logger *slog.Logger, f cmdutil.Factory) (http.Handle
 
 	hnd := func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
+		t0 := time.Now()
 		logger.Info("Received request", "path", r.URL.Path, "host", r.Host, "method", r.Method, "url", r.URL.String())
 
 		if r.Method == http.MethodConnect {
@@ -65,6 +72,8 @@ func (o *Options) wrapServe(logger *slog.Logger, f cmdutil.Factory) (http.Handle
 			http.Error(w, "Error: "+err.Error(), http.StatusInternalServerError)
 			return
 		}
+
+		logger.Info("Routing", "host", r.Host, "pod_namespace", fc.Namespace, "pod_name", fc.PodName, "pod_port", fc.PodPort)
 
 		hdr := http.Header{}
 		hdr.Set(corev1.StreamType, corev1.StreamTypeError)
@@ -88,7 +97,7 @@ func (o *Options) wrapServe(logger *slog.Logger, f cmdutil.Factory) (http.Handle
 		defer fc.Conn.RemoveStreams(dstream)
 
 		r2 := r.Clone(ctx)
-		r2.Body.Close()
+		_ = r2.Body.Close()
 
 		if err := r2.Write(dstream); err != nil {
 			http.Error(w, "cannot write request to data stream: "+err.Error(), http.StatusInternalServerError)
@@ -105,7 +114,7 @@ func (o *Options) wrapServe(logger *slog.Logger, f cmdutil.Factory) (http.Handle
 			return
 		}
 
-		logger.Info("ok", "response_length_bytes", n)
+		logger.Info("ok", "response_length_bytes", n, "request_duration_seconds", time.Since(t0).Seconds())
 		return
 	}
 

--- a/pkg/dynaward/verbosity.go
+++ b/pkg/dynaward/verbosity.go
@@ -1,0 +1,17 @@
+package dynaward
+
+import "github.com/thediveo/enumflag/v2"
+
+type VerbosityLevel enumflag.Flag
+
+const (
+	InfoVerbosityLevel VerbosityLevel = iota
+	DebugVerbosityLevel
+	TraceVerbosityLevel
+)
+
+var VerbosityLevelOptions = map[VerbosityLevel][]string{
+	InfoVerbosityLevel:  {"", "i", "info"},
+	DebugVerbosityLevel: {"d", "debug"},
+	TraceVerbosityLevel: {"t", "trace"},
+}


### PR DESCRIPTION
1. Make listen port configurable with `-L`.
2. Make verbosity configurable with `-l` (lowercase L).
3. Add optional control endpoint at `localhost` with `-c`.
4. Improve the handling of name-based port references in the `targetPort` of a service, such that the port name is resolved to a numeric port before port-forward happens.